### PR TITLE
Add command framework and settings management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 .env
+vendor/

--- a/Commands/AbstractCommand.php
+++ b/Commands/AbstractCommand.php
@@ -111,7 +111,7 @@ abstract class AbstractCommand implements Command
         return $this->argsMap[$arg];
     }
 
-    private function log(string $info): void
+    protected function log(string $info): void
     {
         fwrite(STDOUT , $info . PHP_EOL);
     }

--- a/Commands/AbstractCommand.php
+++ b/Commands/AbstractCommand.php
@@ -2,6 +2,8 @@
 
 namespace Commands;
 
+use Exception;
+
 abstract class AbstractCommand implements Command
 {
     protected ?string $value = null;
@@ -16,6 +18,55 @@ abstract class AbstractCommand implements Command
 
     private function setUpArgsMap()
     {
+        $args = $GLOBALS['argv'];
+        $startIndex = array_search($this->getAlias(), $args);
+
+        if ($startIndex === false) throw new Exception("Command not found: " . $this->getAlias());
+        else $startIndex++;
+
+        $shellArgs = [];
+
+        if (!isset($args[$startIndex]) || ($args[$startIndex][0] === "-")){
+            if($this->isCommandValueRequired()){
+                throw new Exception("Command value is required for command: " . $this->getAlias());
+            }
+        }
+        else{
+            $this->argsMap[$this->getAlias()] = $args[$startIndex];
+            $startIndex++;
+        }
+
+        for ($i = $startIndex; $i < count($args); $i++){
+            $arg = $args[$i];
+
+            if ($arg[0].$arg[1] === "--") $key = substr($arg, 2);
+            else if ($arg[0] === "-") $key = substr($arg, 1);
+            else throw new Exception('Options must start with "--" or "-"');
+
+            $shellArgs[$key] = true;
+            if (isset($args[$i+1]) && $args[$i+1][0] !== "-"){
+                $shellArgs[$key] = $args[$i+1];
+                $i++;
+            }
+        }
+
+        /** @var Argument $argument */
+        foreach ($this->getArguments() as $argument){
+            $argString = $argument->getArgument();
+            $value = null;
+
+            if ($argument->isShortAllowed() && isset($shellArgs[$argString[0]])) $value = $shellArgs[$argString[0]];
+            else if (isset($shellArgs[$argString])) $value = $shellArgs[$argString];
+
+            if ($value === null){
+                if ($argument->isRequired()){
+                    throw new Exception("Argument is required: " . $argString);
+                }
+                else $this->argsMap[$argString] = false;
+            }
+            else $this->argsMap[$argString] = $value;
+        }
+        $this->log(json_encode($this->argsMap));
     }
 
     public static function getAlias(): string
@@ -25,18 +76,46 @@ abstract class AbstractCommand implements Command
 
     public static function getHelp(): string
     {
-        // TODO: Implement getHelp() method.
+        $helpString = "Command: " . static::getAlias() . (static::isCommandValueRequired() ? "{value}": "") . PHP_EOL;
+
+        $arguments = static::getArguments();
+        if (empty($arguments)) return $helpString;
+
+        $helpString .= "Arguments:" . PHP_EOL;
+
+        /* @var Argument $argument */
+        foreach ($arguments as $argument){
+            $helpString .= " --" . $argument->getArgument();
+            if ($argument->isShortAllowed()) {
+                $helpString .= " (-" . $argument->getArgument()[0] . ")";
+            }
+            $helpString .= " : " . $argument->getDescription() . PHP_EOL;
+            $helpString .= "Required: " . ($argument->isRequired() ? "Yes" : "No") . PHP_EOL;
+            $helpString .= PHP_EOL;
+        }
+
+        return $helpString;
     }
 
     public static function isCommandValueRequired(): bool
     {
-        // TODO: Implement isCommandValueRequired() method.
+        return static::$requiredCommandValue;
+    }
+
+    public function getCommandValue(): string{
+        return $this->argsMap[static::getAlias()]??"";
     }
 
     public function getArgumentValue(string $arg): bool|string
     {
         return $this->argsMap[$arg];
     }
+
+    private function log(string $info): void
+    {
+        fwrite(STDOUT , $info . PHP_EOL);
+    }
+
     public abstract static function getArguments(): array;
     public abstract function execute(): int;
 }

--- a/Commands/AbstractCommand.php
+++ b/Commands/AbstractCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Commands;
+
+abstract class AbstractCommand implements Command
+{
+    protected ?string $value = null;
+    protected array $argsMap = [];
+    protected static ?string $alias = null;
+    protected static bool $requiredCommandValue = false;
+
+    public function __construct()
+    {
+        $this->setUpArgsMap();
+    }
+
+    private function setUpArgsMap()
+    {
+    }
+
+    public static function getAlias(): string
+    {
+        return static::$alias !== null ? static::$alias : static::class;
+    }
+
+    public static function getHelp(): string
+    {
+        // TODO: Implement getHelp() method.
+    }
+
+    public static function isCommandValueRequired(): bool
+    {
+        // TODO: Implement isCommandValueRequired() method.
+    }
+
+    public function getArgumentValue(string $arg): bool|string
+    {
+        return $this->argsMap[$arg];
+    }
+    public abstract static function getArguments(): array;
+    public abstract function execute(): int;
+}

--- a/Commands/Argument.php
+++ b/Commands/Argument.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Commands;
+
+class Argument
+{
+    private string $argument;
+    private string $description = "";
+    private bool $required = true;
+    private bool $allowAsShort = false;
+
+    public function __construct(string $argument){
+        $this->argument = $argument;
+    }
+
+    public function getArgument(): string
+    {
+        return $this->argument;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function description(string $description): Argument
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function isRequired(): bool
+    {
+        return $this->required;
+    }
+
+    public function required(bool $required): Argument
+    {
+        $this->required = $required;
+        return $this;
+    }
+
+    public function isShortAllowed(): bool
+    {
+        return $this->allowAsShort;
+    }
+
+    public function allowAsShort(bool $allowAsShort): Argument
+    {
+        $this->allowAsShort = $allowAsShort;
+        return $this;
+    }
+}

--- a/Commands/Command.php
+++ b/Commands/Command.php
@@ -1,0 +1,13 @@
+<?php
+namespace Commands;
+
+interface Command
+{
+    public static function getAlias(): string;
+    public static function getArguments(): array;
+    public static function getHelp(): string;
+    public static function isCommandValueRequired(): bool;
+
+    public function getArgumentValue(string $arg): bool|string;
+    public function execute(): int;
+}

--- a/Commands/Programs/CodeGeneration.php
+++ b/Commands/Programs/CodeGeneration.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Commands\Programs;
+
+use Commands\AbstractCommand;
+
+class CodeGeneration extends AbstractCommand
+{
+
+    public static function getArguments(): array
+    {
+        // TODO: Implement getArguments() method.
+    }
+
+    public function execute(): int
+    {
+        // TODO: Implement execute() method.
+    }
+}

--- a/Commands/Programs/CodeGeneration.php
+++ b/Commands/Programs/CodeGeneration.php
@@ -3,17 +3,64 @@
 namespace Commands\Programs;
 
 use Commands\AbstractCommand;
+use Commands\Argument;
 
 class CodeGeneration extends AbstractCommand
 {
+    protected static ?string $alias = 'code-gen';
+    protected static bool $requiredCommandValue = true;
 
     public static function getArguments(): array
     {
-        // TODO: Implement getArguments() method.
+        return [
+            (new Argument('name'))->description("Name of the file that is to be generate")->required(false),
+        ];
     }
 
     public function execute(): int
     {
-        // TODO: Implement execute() method.
+        $codeGenType = $this->getCommandValue();
+        $this->log("Generating code for.......".$codeGenType);
+        if ($codeGenType === 'migration'){
+            $migrationFile = $this->getArgumentValue('name');
+            $this->generateMigrationFile($migrationFile);
+        }
+        return 0;
+    }
+
+    private function generateMigrationFile(string $migrationFile): void
+    {
+        $filename = sprintf('%s_%s_%s.php', date('Y-m-d'), time(), $migrationFile);
+        $migrationContent = $this->getMigrationContent($migrationFile);
+        $path = sprintf("%s/../../Database/Migrations/%s", __DIR__, $filename);
+        file_put_contents($path, $migrationContent);
+    }
+
+    private function getMigrationContent(string $migrationFile): string
+    {
+        $className = $this->pascalCase($migrationFile);
+        return <<<MIGRATION
+<?php
+namespace Database\Migrations;
+use Database\SchemaMigration;
+
+class {$className} implements SchemaMigration
+{
+    public function up(): array
+    {
+        return [];
+    }
+
+    public function down(): array
+    {
+        return[];
+    }
+}
+MIGRATION;
+    }
+
+    private function pascalCase(string $migrationFile): string
+    {
+        return str_replace(" ", "", ucwords(str_replace(['-', '_'], ' ', $migrationFile)));
     }
 }

--- a/Commands/Programs/Migrate.php
+++ b/Commands/Programs/Migrate.php
@@ -4,6 +4,7 @@ namespace Commands\Programs;
 
 use Commands\AbstractCommand;
 use Commands\Argument;
+use Database\MySQLWrapper;
 
 class Migrate extends AbstractCommand
 {

--- a/Commands/Programs/Migrate.php
+++ b/Commands/Programs/Migrate.php
@@ -13,8 +13,8 @@ class Migrate extends AbstractCommand
     public static function getArguments(): array
     {
         return [
-            (new Argument('rollback')->description('Rollback the last migration')->allowAsShort(true)->required(false)),
-            (new Argument('init')->description('Create migration table if it does not exist')->allowAsShort(true)->required(false)),
+            (new Argument('rollback'))->description('Rollback the last migration')->allowAsShort(true)->required(false),
+            (new Argument('init'))->description('Create migration table if it does not exist')->allowAsShort(true)->required(false),
         ];
     }
 

--- a/Commands/Programs/Migrate.php
+++ b/Commands/Programs/Migrate.php
@@ -117,9 +117,21 @@ class Migrate extends AbstractCommand
 
     private function processQueries(array $queries)
     {
+        $mysqli = new MySQLWrapper();
+
+        foreach ($queries as $query){
+            $result = $mysqli->query($query);
+            if ($result === false) throw new \Exception("Failed to run query: $query");
+        }
     }
 
-    private function insertMigration(string $filename)
+    private function insertMigration(string $filename): void
     {
+        $mysqli = new MySQLWrapper();
+        $statement = $mysqli->prepare("INSERT INTO migrations (filename, created_at) VALUES (?, NOW())");
+        $statement->bind_param('s', $filename);
+        if (!$statement->execute()) throw new \Exception("Failed to insert migration table");
+
+        $statement->close();
     }
 }

--- a/Commands/Programs/Migrate.php
+++ b/Commands/Programs/Migrate.php
@@ -3,17 +3,92 @@
 namespace Commands\Programs;
 
 use Commands\AbstractCommand;
+use Commands\Argument;
 
 class Migrate extends AbstractCommand
 {
+    protected static ?string $alias = 'migrate';
 
     public static function getArguments(): array
     {
-        // TODO: Implement getArguments() method.
+        return [
+            (new Argument('rollback')->description('Rollback the last migration')->allowAsShort(true)->required(false)),
+            (new Argument('init')->description('Create migration table if it does not exist')->allowAsShort(true)->required(false)),
+        ];
     }
 
     public function execute(): int
     {
-        // TODO: Implement execute() method.
+        $rollback = $this->getArgumentValue('rollback');
+
+        if ($this->getArgumentValue('init')) {
+            $this->createMigrationTable();
+        }
+
+        if ($rollback === false){
+            $this->log("Starting migration");
+            $this->migrate();
+        }
+        else{
+            $rollbackN = $rollback === true ? 1: (int)$rollback;
+            $this->rollback($rollbackN);
+        }
+        return 0;
+    }
+
+    private function migrate(): void
+    {
+        $this->log("Running migrations...");
+
+        $lastMigrationFile = $this->getLastMigrationFile();
+
+        /* @var string[] $allMigrationFiles */
+        $allMigrationFiles = $this->getAllMigrations();
+        $startIndex = ($lastMigrationFile)? array_search($lastMigrationFile, $allMigrationFiles) + 1: 0;
+
+        for ($i = $startIndex; $i < count($allMigrationFiles); $i++){
+            $filename = $allMigrationFiles[$i];
+            include_once($filename);
+
+            $migrateClassName = $this->getClassNameFromMigrationFile($filename);
+            $migration = new $migrateClassName();
+
+            /* @var string[] $queries */
+            $queries = $migration->up();
+
+            if (empty($queries)) throw new \Exception("Migration must return queries");
+
+            $this->processQueries($queries);
+            $this->insertMigration($filename);
+        }
+        $this->log("Migration completed");
+    }
+
+    private function rollback(int $rollbackN)
+    {
+    }
+
+    private function createMigrationTable()
+    {
+    }
+
+    private function getLastMigrationFile(): string
+    {
+    }
+
+    private function getAllMigrations(): array
+    {
+    }
+
+    private function getClassNameFromMigrationFile(string $filename): string
+    {
+    }
+
+    private function processQueries(array $queries)
+    {
+    }
+
+    private function insertMigration(string $filename)
+    {
     }
 }

--- a/Commands/Programs/Migrate.php
+++ b/Commands/Programs/Migrate.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Commands\Programs;
+
+use Commands\AbstractCommand;
+
+class Migrate extends AbstractCommand
+{
+
+    public static function getArguments(): array
+    {
+        // TODO: Implement getArguments() method.
+    }
+
+    public function execute(): int
+    {
+        // TODO: Implement execute() method.
+    }
+}

--- a/Commands/Programs/Migrate.php
+++ b/Commands/Programs/Migrate.php
@@ -85,8 +85,16 @@ class Migrate extends AbstractCommand
         $this->log("Migration table created");
     }
 
-    private function getLastMigrationFile(): string
+    private function getLastMigrationFile(): ?string
     {
+        $mysqli = new MySQLWrapper();
+        $result = $mysqli->query("SELECT filename FROM migrations ORDER BY id DESC LIMIT 1");
+
+        if ($result && $result->num_rows === 0){
+            $rows = $result->fetch_assoc();
+            return $rows['filename'];
+        }
+        return null;
     }
 
     private function getAllMigrations(): array

--- a/Commands/Programs/Migrate.php
+++ b/Commands/Programs/Migrate.php
@@ -70,6 +70,19 @@ class Migrate extends AbstractCommand
 
     private function createMigrationTable()
     {
+        $this->log("Creating migration table");
+        $mysqli = new MySQLWrapper();
+
+        $result = $mysqli->query("
+            CREATE TABLE IF NOT EXISTS migrations (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            filename VARCHAR(255) NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )");
+
+        if ($result === false) throw new \Exception("Failed to create migration table");
+
+        $this->log("Migration table created");
     }
 
     private function getLastMigrationFile(): string

--- a/Commands/Programs/Migrate.php
+++ b/Commands/Programs/Migrate.php
@@ -97,12 +97,22 @@ class Migrate extends AbstractCommand
         return null;
     }
 
-    private function getAllMigrations(): array
+    private function getAllMigrations(string $order='asc'): array
     {
+        $directory = sprintf("%s/../../Database/Migrations", __DIR__);
+        $allFiles = glob($directory . '/*.php');
+
+        usort ($allFiles, function($a, $b) use($order){
+            $compareResult = strcmp($a, $b);
+            return $order === 'desc' ? -$compareResult: $compareResult;
+        });
+        return $allFiles;
     }
 
     private function getClassNameFromMigrationFile(string $filename): string
     {
+        if (preg_match("/([^_]+)\.php$/", $filename, $matches)) return sprintf("Database\Migrations\%s", $matches[1]);
+        else throw new \Exception("Unexpected migration file name");
     }
 
     private function processQueries(array $queries)

--- a/Commands/registry.php
+++ b/Commands/registry.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    Commands\Programs\Migrate::class,
+    Commands\Programs\CodeGeneration::class,
+];

--- a/Database/MySQLWrapper.php
+++ b/Database/MySQLWrapper.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database;
+
+use Helpers\Settings;
+use mysqli;
+
+class MySQLWrapper extends mysqli
+{
+    public function __construct(?string $hostname = 'localhost', ?string $username = null, ?string $password = null, ?string $database = null, ?int $port = null, ?string $socket = null)
+    {
+        mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+        $database = $database?? Settings::env('DATABASE_NAME');
+        $username = $username?? Settings::env('DATABASE_USER');
+        $password = $password?? Settings::env('DATABASE_USER_PASSWORD');
+
+        parent::__construct($hostname, $username, $password, $database, $port, $socket);
+    }
+}

--- a/Database/SchemaMigration.php
+++ b/Database/SchemaMigration.php
@@ -1,0 +1,8 @@
+<?php
+namespace Database;
+
+interface SchemaMigration
+{
+    public function up();
+    public function down();
+}

--- a/Helpers/Settings.php
+++ b/Helpers/Settings.php
@@ -1,0 +1,14 @@
+<?php
+namespace Helpers;
+
+class Settings{
+    private const ENV_PATH = ".env";
+
+    public static function env(string $pair): string{
+        $config = parse_ini_file(dirname(__FILE__, 2) . '/' . self::ENV_PATH);
+        if($config === false){
+            throw new \Exception("Error reading .env file");
+        }
+        return $config[$pair];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+  "autoload": {
+    "psr-4": {
+    }
+  },
+  "require": {
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,9 @@
 {
   "autoload": {
     "psr-4": {
+      "Commands\\": "Commands/",
+        "Database\\": "Database/",
+      "Helpers\\": "Helpers/"
     }
   },
   "require": {

--- a/console
+++ b/console
@@ -1,0 +1,24 @@
+<?php
+require 'vendor/autoload.php';
+
+$commands = include_once "Commands/registry.php";
+
+$inputCommand = $argv[1];
+
+/** @var Commands\AbstractCommand $commandClass */
+foreach ($commands as $commandClass){
+    $alias = $commandClass::getAlias();
+    if ($alias === $inputCommand){
+        if (in_array("--help", $argv)){
+            fwrite(STDOUT, $commandClass::getHelp());
+            exit(0);
+        }
+        else{
+            $commandClass = new $commandClass();
+            $result = $commandClass->execute();
+            exit($result);
+        }
+    }
+}
+
+fwrite(STDOUT, "Command not found: $inputCommand");


### PR DESCRIPTION
## 実装内容
- AbstractCommandクラスの追加実装
  - setUpArgsMap関数を実装し、コマンドライン引数のマッピングを設定
  - getHelp関数を実装し、コマンドのヘルプ文字列を生成
  - isCommandValueRequired関数を実装し、コマンド値が必要かどうかを判定
  - log関数を実装し、情報を標準出力に記録
- CodeGenerationクラスの追加実装
  - AbstractCommandクラスを継承
  - getArguments関数を追加（未実装）
  - execute関数を追加（未実装）
- Migrateクラスの実装
  - getArguments関数を実装し、rollbackとinit引数を定義
  - execute関数を実装し、マイグレーションの実行とロールバックを処理
  - migrate関数を追加し、マイグレーションの実行ロジックを実装
  - rollback関数を追加し、指定された回数分のマイグレーションをロールバック
  - createMigrationTable関数を実装し、マイグレーションテーブルを作成
  - getLastMigrationFile関数を実装し、最後に実行されたマイグレーションファイルを取得
  - getAllMigrations関数を実装し、全てのマイグレーションファイルを取得
  - getClassNameFromMigrationFile関数を実装し、マイグレーションファイル名からクラス名を生成
  - processQueries関数を実装し、マイグレーションクエリを実行
  - insertMigration関数を実装し、実行済みのマイグレーションを記録
  - deleteLastMigration関数を実装し、指定されたマイグレーションファイルを削除
- MySQLWrapperクラスの実装
  - mysqliクラスを拡張し、データベース接続をラップ
  - コンストラクタを実装し、環境変数からデータベース接続情報を取得
- コンソールスクリプトの実装
  - コマンドライン引数からコマンドを取得し、対応するコマンドクラスを実行
  - コマンドレジストリからコマンドクラスを読み込み
  - --helpオプションが指定された場合、コマンドのヘルプを表示
  - コマンドが見つからない場合、エラーメッセージを表示

## 動作確認
[x] php console code-gen --name TableでMigrationファイルの生成を確認
[] php console migrateの確認(--roleback, --init)
