### PR TITLE
Register logoutの実装

### DIFF
--- a/Helpers/Authenticate.php
+++ b/Helpers/Authenticate.php
@@ -34,4 +34,15 @@ class Authenticate
             throw new \Exception('Invalid password.');
         }
     }
+
+    public static function logoutUser(): bool
+    {
+        if (isset($_SESSION[self::USER_ID_SESSION])){
+            unset($_SESSION[self::USER_ID_SESSION]);
+            self::$authenticatedUser = null;
+            return true;
+        } else {
+            throw new \Exception('No user to logout.');
+        }
+    }
 }

--- a/Helpers/Authenticate.php
+++ b/Helpers/Authenticate.php
@@ -10,7 +10,7 @@ class Authenticate
     private static ?User $authenticatedUser = null;
     private const USER_ID_SESSION = 'user_id';
 
-    private static function loginAsUser(?User $authenticatedUser): bool
+    public static function loginAsUser(?User $authenticatedUser): bool
     {
         if ($authenticatedUser->getId() === null) throw new \Exception('Cannot login a user with no ID.');
         if (isset($_SESSION[self::USER_ID_SESSION])) throw new \Exception('User is already logged in. Logout before continuing.');

--- a/Routing/routes.php
+++ b/Routing/routes.php
@@ -19,4 +19,9 @@ return [
         Authenticate::authenticate($email, $password);
         return new RedirectRenderer('login');
     }),
+
+    'logout' => Route::create('logout', function() {
+        Authenticate::logoutUser();
+        return new RedirectRenderer('login');
+    }),
 ];

--- a/Routing/routes.php
+++ b/Routing/routes.php
@@ -1,8 +1,10 @@
 <?php
 namespace Routing;
 
+use Database\DAOFactory;
 use Exception;
 use Helpers\Authenticate;
+use Models\User;
 use Response\Render\HTMLRenderer;
 use Response\Render\RedirectRenderer;
 
@@ -24,4 +26,29 @@ return [
         Authenticate::logoutUser();
         return new RedirectRenderer('login');
     }),
+
+    'register' => Route::create('register', function() {
+        return new HTMLRenderer('page/register', []);
+    }),
+
+    'form/register' => Route::create('/form/register', function (){
+        if (!$_SERVER["REQUEST_METHOD"] === 'POST') throw new Exception('Invalid request method: ' . $_SERVER["REQUEST_METHOD"]);
+
+        $username = $_POST['username'] ?? '';
+        $email = $_POST['email'] ?? '';
+        $password = $_POST['password'] ?? '';
+        $passwordConfirmation = $_POST['confirm-password'] ?? '';
+
+        if($password !== $passwordConfirmation) throw new Exception('Password and password confirmation do not match.');
+
+        $userDao = DAOFactory::getUserDAO();
+        $user = new User(username: $username, email: $email);
+
+        $success = $userDao->create($user, $password);
+        if(!$success) throw new Exception('Failed to create user.');
+
+        Authenticate::loginAsUser($user);
+        error_log('User created: ' . json_encode($user));
+        return new RedirectRenderer('login');
+    })
 ];

--- a/Views/page/register.php
+++ b/Views/page/register.php
@@ -1,0 +1,80 @@
+<header class="flex items-center justify-between px-10 py-3 border-b border-[#f0f2f5]">
+    <div class="flex items-center gap-4">
+        <h1 class="text-lg font-bold">Chirp</h1>
+    </div>
+</header>
+<main class="flex justify-center py-5 px-4">
+    <div class="w-full max-w-md">
+        <h2 class="text-[28px] font-bold leading-tight mb-5">Create an account</h2>
+        <form action="form/register" method="post" class="space-y-6">
+            <div>
+                <label class="block text-sm font-medium mb-2" for="username">Username</label>
+                <input
+                    id="username"
+                    name="username"
+                    type="text"
+                    placeholder="e.g. claraoswald"
+                    class="w-full h-12 px-4 border border-[#dbe1e6] rounded-xl focus:border-[#2094f3] focus:outline-none"
+                    aria-label="Username"
+                    required
+                />
+            </div>
+            <div>
+                <label class="block text-sm font-medium mb-2" for="email">Email</label>
+                <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    placeholder="you@example.com"
+                    class="w-full h-12 px-4 border border-[#dbe1e6] rounded-xl focus:border-[#2094f3] focus:outline-none"
+                    aria-label="Email"
+                    required
+                />
+            </div>
+            <div>
+                <label class="block text-sm font-medium mb-2" for="password">Password</label>
+                <input
+                    id="password"
+                    name="password"
+                    type="password"
+                    placeholder="At least 8 characters, uppercase, lowercase, number, and special character"
+                    class="w-full h-12 px-2 border border-[#dbe1e6] rounded-xl focus:border-[#2094f3] focus:outline-none"
+                    aria-label="Password"
+                    required
+                />
+            </div>
+            <div>
+                <label class="block text-sm font-medium mb-2" for="confirm-password">Confirm Password</label>
+                <input
+                        id="confirm-password"
+                        name="confirm-password"
+                        type="password"
+                        placeholder="At least 8 characters, uppercase, lowercase, number, and special character"
+                        class="w-full h-12 px-2 border border-[#dbe1e6] rounded-xl focus:border-[#2094f3] focus:outline-none"
+                        aria-label="confirm-Password"
+                        required
+                />
+            </div>
+            <div class="flex items-start gap-3">
+                <input
+                    id="terms"
+                    name="terms"
+                    type="checkbox"
+                    class="h-5 w-5 rounded border-[#dbe1e6] focus:ring-0 focus:ring-offset-0"
+                    required
+                />
+                <label for="terms" class="text-sm">
+                    By signing up, you agree to our <a href="#" class="underline">Terms of Service</a> and <a href="#" class="underline">Privacy Policy</a>.
+                </label>
+            </div>
+            <button
+                type="submit"
+                class="w-full h-12 bg-[#2094f3] text-white font-bold rounded-xl"
+            >
+                Register
+            </button>
+        </form>
+        <p class="mt-4 text-sm text-center">
+            Already have an account? <a href="#" class="underline">Log in</a>.
+        </p>
+    </div>


### PR DESCRIPTION
このプルリクエストでは、認証および登録システムにいくつかの新機能と改善が導入されています。主な変更点は、`loginAsUser`関数をパブリックに変更、`logoutUser`関数の追加、ユーザー登録およびログアウトをサポートするルーティングの更新、新しい登録ビューの作成です。

### 認証機能の強化:
* [`Helpers/Authenticate.php`](diffhunk://#diff-57c1971490d0073373616c2f7dc8842f276154f635f42f42adab254d44eb0fe1L13-R13): `loginAsUser`関数をプライベートからパブリックに変更し、外部からの呼び出しを可能にしました。また、ユーザーログアウトを処理する新しい`logoutUser`関数を追加。  
  
### ルーティングの更新:
* [`Routing/routes.php`](diffhunk://#diff-b3783f7505620e7476ae19ed5c392eac0028925199d642212a3c2028bb5e5ae0R4-R7): ユーザー登録およびログアウト用の新しいルートを追加し、これらのアクションを処理するための必要なロジックを実装。  
 
### ユーザーインターフェース:
* [`Views/page/register.php`](diffhunk://#diff-0028126dccd80b012b64944aafbb0e76d10dd0789afe3968ef4e8789ade8f405R1-R80): ユーザーがアカウントを作成するためのフォームを備えた新しい登録ページを作成。フォームには、ユーザー名、メールアドレス、パスワード、パスワード確認のフィールドを含む。
