### PR TITLE
CSRF実装

### DIFF
--- a/Helpers/CrossSiteForgeryProtection.php
+++ b/Helpers/CrossSiteForgeryProtection.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Helpers;
+
+class CrossSiteForgeryProtection
+{
+    public static function getToken()
+    {
+        return $_SESSION['csrf_token'];
+    }
+}

--- a/Middleware/CSRFMiddleware.php
+++ b/Middleware/CSRFMiddleware.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Middleware;
+
+use Middleware\Middleware;
+use Response\FlashData;
+use Response\HTTPRenderer;
+use Response\Render\RedirectRenderer;
+
+class CSRFMiddleware implements Middleware
+{
+
+    public function handle(callable $next): HTTPRenderer
+    {
+        if (!isset($_SESSION['csrf_token'])) {
+            $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+        }
+        $token = $_SESSION['csrf_token'];
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST'){
+            if ($_POST['csrf_token'] !== $token){
+                FlashData::setFlashData('error', 'Access has been denied');
+                return new RedirectRenderer('login');
+            }
+        }
+        return $next();
+    }
+}

--- a/Middleware/middleware-register.php
+++ b/Middleware/middleware-register.php
@@ -2,6 +2,7 @@
 return [
     'global' => [
         \Middleware\SessionsSetupMiddleware::class,
+        \Middleware\CSRFMiddleware::class,
     ],
     'aliases' => [
         'guest' => \Middleware\GuestMiddleware::class,

--- a/Views/page/login.php
+++ b/Views/page/login.php
@@ -28,6 +28,7 @@
     <h1 class="text-4xl font-bold text-center mb-4">Welcome back to Chirp</h1>
     <p class="text-center mb-6">The best place to share your thoughts with the world. Log in to get started.</p>
     <form class="w-full max-w-md" action="form/login" method="post">
+        <input type="hidden" name="csrf_token" value=<?= Helpers\CrossSiteForgeryProtection::getToken(); ?>>
         <label for="email" class="block mb-2">Email</label>
         <input
                 type="email"

--- a/Views/page/profile.php
+++ b/Views/page/profile.php
@@ -122,6 +122,7 @@
             <h2 class="text-xl font-bold mb-4">Edit Profile</h2>
             <form action="form/edit-profile" method="post">
                 <div class="mb-4">
+                    <input type="hidden" name="csrf_token" value=<?= \Helpers\CrossSiteForgeryProtection::getToken(); ?>
                     <label for="username" class="block text-sm font-medium">Name</label>
                     <input
                             id="username"
@@ -194,3 +195,4 @@
             </form>
         </div>
     </div>
+</main>

--- a/Views/page/register.php
+++ b/Views/page/register.php
@@ -7,6 +7,7 @@
     <div class="w-full max-w-md">
         <h2 class="text-[28px] font-bold leading-tight mb-5">Create an account</h2>
         <form action="form/register" method="post" class="space-y-6">
+            <input type="hidden" name="csrf_token" value=<?= Helpers\CrossSiteForgeryProtection::getToken(); ?>>
             <div>
                 <label class="block text-sm font-medium mb-2" for="username">Username</label>
                 <input


### PR DESCRIPTION
このプルリクエストでは、アプリケーションにクロスサイトリクエストフォージェリ（CSRF）保護を導入しました。これには、ミドルウェアの実装と関連するフォームへのCSRFトークンの追加が含まれます。主な変更点は、CSRF保護ヘルパークラスの作成、CSRFミドルウェアの追加、およびフォーム送信へのCSRFトークンの統合です。

### CSRF保護の実装:

* [`Helpers/CrossSiteForgeryProtection.php`](diffhunk://#diff-3a087ef30ec05b9d8297f77d862b5c9aad107f53c98c8b225ffa925f471afd3dR1-R11):  
  CSRFトークンを生成および取得するための新しいヘルパークラス`CrossSiteForgeryProtection`を追加。
* [`Middleware/CSRFMiddleware.php`](diffhunk://#diff-4425e4e973c97cb89d7c3dad9d84d1a13d8f8b536909099cfc8b312c57ab617cR1-R28):  
  CSRFトークンの生成と検証を処理する新しいミドルウェア`CSRFMiddleware`を導入。
* [`Middleware/middleware-register.php`](diffhunk://#diff-9cbd4682485d4f0f59255e6fa1e11537667f2590b5d11dccda1669bb2ffcf211R5):  
  `CSRFMiddleware`をグローバルミドルウェアスタックに登録。

### フォームへの統合:

* [`Views/page/login.php`](diffhunk://#diff-c6347f31615b09e0922930dc374e99ae14a88f0aa491f80bfede4a7fae49532fR31):  
  ログインフォームにCSRFトークンのための非表示入力フィールドを追加。
* [`Views/page/profile.php`](diffhunk://#diff-269cfd1ea26ce6eb7ae301c23007f6b49137654de46ff700eee7397afc78a4dbR125):  
  プロフィール編集フォームにCSRFトークンのための非表示入力フィールドを追加。
* [`Views/page/register.php`](diffhunk://#diff-0028126dccd80b012b64944aafbb0e76d10dd0789afe3968ef4e8789ade8f405R10):  
  登録フォームにCSRFトークンのための非表示入力フィールドを追加。
