### PR TITLE
シーディング、マイグレーション、およびデータアクセスの機能改善

### DIFF
--- a/Database/AbstractSeeder.php
+++ b/Database/AbstractSeeder.php
@@ -12,8 +12,11 @@ abstract class AbstractSeeder implements Seeder
     protected array $tableColumns = [];
     const AVAILABLE_TYPES = [
         'int' => 'i',
+        '?int' => 'i',
         'float' => 'd',
+        '?float' => 'd',
         'string' => 's',
+        '?string' => 's',
     ];
 
     public function __construct(MySQLWrapper $conn)
@@ -36,14 +39,16 @@ abstract class AbstractSeeder implements Seeder
     private function validateRow(array $row): void
     {
         if (count($row) !== count($this->tableColumns)) throw new \Exception("Column count mismatch");
-
             foreach ($row as $i => $value) {
 
                 $columnDataType = $this->tableColumns[$i]['data_type'];
-                $columnName = $this->tableColumns[$i]['column_name'];
+                if (str_contains($columnDataType, "?")) {
+                    $columnDataType = str_replace("?", "", $columnDataType);
+                }
 
+                if ($this->tableColumns[$i]['data_type'] === '?int' && $value === null) continue;
                 if (!isset(self::AVAILABLE_TYPES[$columnDataType])) throw new \InvalidArgumentException(sprintf("Invalid data type %s", $columnDataType));
-                if (get_debug_type($value) !== $columnDataType) throw new \InvalidArgumentException(sprintf("Value for %s should be of type %s. Here is the current value: %s", $columnName, $columnDataType, json_encode($value)));
+                if ((get_debug_type($value) !== $columnDataType)) throw new \InvalidArgumentException(sprintf("Value for %s should be of type %s. Here is the current value: %s", $columnName, $columnDataType, json_encode($value)));
             }
     }
 

--- a/Database/DataAccess/UserDAO.php
+++ b/Database/DataAccess/UserDAO.php
@@ -10,4 +10,5 @@ interface UserDAO
     public function getByEmail(string $email): ?User;
     public function getHashedPasswordById(int $id): ?string;
     public function updateProfile(array $data): bool;
+    public function getAll(): array;
 }

--- a/Database/Migrations/2024-12-26_1735211451_UpdateMessageTable1.php
+++ b/Database/Migrations/2024-12-26_1735211451_UpdateMessageTable1.php
@@ -1,0 +1,20 @@
+<?php
+namespace Database\Migrations;
+use Database\SchemaMigration;
+
+class UpdateMessageTable1 implements SchemaMigration
+{
+    public function up(): array
+    {
+        return [
+            "ALTER TABLE messages MODIFY COLUMN receiverId INT"
+        ];
+    }
+
+    public function down(): array
+    {
+        return[
+            "ALTER TABLE messages MODIFY COLUMN receiverId INT NOT NULL"
+        ];
+    }
+}

--- a/Database/Seeds/MessageSeeder.php
+++ b/Database/Seeds/MessageSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Seeds;
+
+use Database\AbstractSeeder;
+use Faker\Factory;
+
+class MessageSeeder extends AbstractSeeder
+{
+
+    protected ?string $tableName = 'messages';
+    protected array $tableColumns = [
+        'content' => [
+            'data_type' => 'string',
+            'column_name' => 'content'
+        ],
+        'senderId' => [
+            'data_type' => 'int',
+            'column_name' => 'senderId'
+        ],
+        'receiverId' => [
+            'data_type' => 'int',
+            'column_name' => 'receiverId'
+        ],
+        'created_at' => [
+            'data_type' => 'string',
+            'column_name' => 'created_at'
+        ],
+    ];
+
+    public function createRowData(int $num=1): array
+    {
+        $data = [];
+        $faker = Factory::create();
+        for ($i = 0; $i < $num; $i++){
+            $data[] = [
+                'content' => $faker->text,
+                'senderId' => $faker->numberBetween(1, 10),
+                'receiverId' => $faker->numberBetween(1, 10),
+                'created_at' => $faker->dateTimeThisYear->format('Y-m-d H:i:s')
+            ];
+        }
+        return $data;
+    }
+}

--- a/Database/Seeds/MessageSeeder.php
+++ b/Database/Seeds/MessageSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeds;
 
 use Database\AbstractSeeder;
+use Database\DAOFactory;
 use Faker\Factory;
 
 class MessageSeeder extends AbstractSeeder
@@ -19,7 +20,7 @@ class MessageSeeder extends AbstractSeeder
             'column_name' => 'senderId'
         ],
         'receiverId' => [
-            'data_type' => 'int',
+            'data_type' => '?int',
             'column_name' => 'receiverId'
         ],
         'created_at' => [
@@ -30,13 +31,22 @@ class MessageSeeder extends AbstractSeeder
 
     public function createRowData(int $num=1): array
     {
+        $userDao = DAOFactory::getUserDAO();
+        $users = $userDao->getAll();
+        $ids = [];
+        foreach ($users as $user){
+            $ids[] = $user->getId();
+        }
+        $senderIds = $ids;
+        $receiverIds = $ids + [null];
+
         $data = [];
         $faker = Factory::create();
         for ($i = 0; $i < $num; $i++){
             $data[] = [
                 'content' => $faker->text,
-                'senderId' => $faker->numberBetween(1, 10),
-                'receiverId' => $faker->numberBetween(1, 10),
+                'senderId' => $faker->randomElement($senderIds),
+                'receiverId' => $faker->randomElement($receiverIds),
                 'created_at' => $faker->dateTimeThisYear->format('Y-m-d H:i:s')
             ];
         }


### PR DESCRIPTION
このプルリクエストでは、データベースのシーディングとマイグレーション機能に関するいくつかの変更と、データアクセスオブジェクト（DAO）の更新が含まれています。主な変更点は、`AbstractSeeder`クラスでのNULL可能なデータ型のサポート、`UserDAO`への新しいメソッドの追加、および`messages`テーブルの新しいマイグレーションとシーダークラスの作成です。

### `AbstractSeeder`の改良:

* [`Database/AbstractSeeder.php`](diffhunk://#diff-0b44011147f0772b4a4fd696d106f85f5e52920c33d48d9acad7b400c939f58dR15-R19):  
  `AVAILABLE_TYPES`配列に`?int`、`?float`、`?string`といったNULL可能なデータ型のサポートを追加し、`validateRow`メソッドを更新してNULL可能な型を正しく処理できるように改良。  
  [[1]](diffhunk://#diff-0b44011147f0772b4a4fd696d106f85f5e52920c33d48d9acad7b400c939f58dR15-R19)  [[2]](diffhunk://#diff-0b44011147f0772b4a4fd696d106f85f5e52920c33d48d9acad7b400c939f58dL39-R51)

### `MessageSeeder.php`追加
* radomにMessage Tableにデータを追加するSeederを作成。

### データアクセスオブジェクトの更新:

* [`Database/DataAccess/UserDAO.php`](diffhunk://#diff-f9eeae7539948ddeb03e82bde2dbaaf2223334a09fb93b56cb60e3f6a219458bR13):  
  すべてのユーザーを取得するための新しいメソッド`getAll`を追加。

### 新しいマイグレーションとシーダークラス:

* [`Database/Migrations/2024-12-26_1735211451_UpdateMessageTable1.php`](diffhunk://#diff-d8423b8a5ef2cd9057d71306b4a3d4658888a86cd9096e9ec7560c719ca622ffR1-R20):  
  `messages`テーブルの`receiverId`列を修正する新しいマイグレーションクラス`UpdateMessageTable1`を作成。
* [`Database/Seeds/MessageSeeder.php`](diffhunk://#diff-eaca30eb53e2edf1e8aacc061d077398c20b652126f1e249f544c41d8bb45e57R1-R55):  
  `messages`テーブルにデータをシードするための新しいシーダークラス`MessageSeeder`を作成し、NULL可能な`receiverId`の処理を追加。
