### PR TITLE
データアクセスとシーディング機能の追加

### DIFF
--- a/Database/AbstractSeeder.php
+++ b/Database/AbstractSeeder.php
@@ -17,6 +17,8 @@ abstract class AbstractSeeder implements Seeder
         '?float' => 'd',
         'string' => 's',
         '?string' => 's',
+        'bool' => 'i',
+        '?bool' => 'i',
     ];
 
     public function __construct(MySQLWrapper $conn)
@@ -40,13 +42,14 @@ abstract class AbstractSeeder implements Seeder
     {
         if (count($row) !== count($this->tableColumns)) throw new \Exception("Column count mismatch");
             foreach ($row as $i => $value) {
+                $columnName = $this->tableColumns[$i]['column_name'];
 
                 $columnDataType = $this->tableColumns[$i]['data_type'];
                 if (str_contains($columnDataType, "?")) {
                     $columnDataType = str_replace("?", "", $columnDataType);
                 }
 
-                if ($this->tableColumns[$i]['data_type'] === '?int' && $value === null) continue;
+                if (($this->tableColumns[$i]['data_type'] === '?int' || $this->tableColumns[$i]['data_type'] === '?string') && $value === null) continue;
                 if (!isset(self::AVAILABLE_TYPES[$columnDataType])) throw new \InvalidArgumentException(sprintf("Invalid data type %s", $columnDataType));
                 if ((get_debug_type($value) !== $columnDataType)) throw new \InvalidArgumentException(sprintf("Value for %s should be of type %s. Here is the current value: %s", $columnName, $columnDataType, json_encode($value)));
             }

--- a/Database/DAOFactory.php
+++ b/Database/DAOFactory.php
@@ -3,8 +3,10 @@
 namespace Database;
 
 use Database\DataAccess\MessageDAO;
+use Database\DataAccess\PostDAO;
 use Database\DataAccess\UserDAO;
 use Database\Implementations\MessageDAOImpl;
+use Database\Implementations\PostDAOImpl;
 use Database\Implementations\UserDAOImpl;
 
 class DAOFactory
@@ -17,5 +19,10 @@ class DAOFactory
     public static function getMessageDAO(): MessageDAO
     {
         return new MessageDAOImpl();
+    }
+
+    public static function getPostDAO(): PostDAO
+    {
+        return new PostDAOImpl();
     }
 }

--- a/Database/DataAccess/FollowDAO.php
+++ b/Database/DataAccess/FollowDAO.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Database\DataAccess;
+
+use Models\Follow;
+
+interface FollowDAO
+{
+    public function create(Follow $follow): bool;
+    public function getById(int $id): ?Follow;
+    public function getByFollowerId(int $followerId): ?array;
+    public function getByFollowedId(int $followedId): ?array;
+}

--- a/Database/DataAccess/LikeDAO.php
+++ b/Database/DataAccess/LikeDAO.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Database\DataAccess;
+
+use Models\Like;
+
+interface LikeDAO
+{
+    public function create(Like $like): bool;
+    public function getById(int $id): ?Like;
+    public function getByUserId(int $userId): ?array;
+    public function getByPostId(int $postId): ?array;
+}

--- a/Database/DataAccess/PostDAO.php
+++ b/Database/DataAccess/PostDAO.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\DataAccess;
+
+use Models\Post;
+
+interface PostDAO
+{
+    public function create(Post $post): bool;
+    public function getById(int $id): ?Post;
+    public function getByUserId(int $userId): ?array;
+    public function countByUserId($userId): int;
+    
+}

--- a/Database/DataAccess/PostDAO.php
+++ b/Database/DataAccess/PostDAO.php
@@ -9,6 +9,6 @@ interface PostDAO
     public function create(Post $post): bool;
     public function getById(int $id): ?Post;
     public function getByUserId(int $userId): ?array;
-    public function countByUserId($userId): int;
-    
+    public function countByUserId(int $userId): int;
+    public function getAll():array;
 }

--- a/Database/Implementations/PostDAOImpl.php
+++ b/Database/Implementations/PostDAOImpl.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Database\Implementations;
+
+use Database\DataAccess\PostDAO;
+use Database\MySQLWrapper;
+use Models\Post;
+
+class PostDAOImpl implements PostDAO
+{
+
+    public function create(Post $post): bool
+    {
+        if ($post->getId() == null) throw new \Exception("Post id cannot be null");
+
+        $mysqli = new MySQLWrapper();
+        $query = "INSERT INTO posts (userId, content) VALUE (?, ?)";
+
+        $result = $mysqli->prepareAndExecute(
+            $query,
+            'is',
+            [
+                $post->getUserId(),
+                $post->getContent()
+            ]
+        );
+
+        if (!$result) return false;
+        return true;
+    }
+
+    public function getById(int $id): ?Post
+    {
+        return null;
+    }
+
+    public function getByUserId(int $userId): ?array
+    {
+        return null;
+    }
+
+    public function countByUserId(int $userId): int
+    {
+        return 0;
+    }
+
+    public function getAll(): array
+    {
+        $mysqli = new MySQLWrapper();
+        $query = "SELECT * FROM posts";
+        $rawData = $mysqli->query($query);
+        $posts = [];
+        foreach ($rawData as $rawPost) {
+            $posts[] = $this->rawDataToPost($rawPost);
+        }
+        return $posts;
+    }
+
+    private function rawDataToPost(array $rawPost): Post
+    {
+        return new Post(
+            userId: $rawPost['userId'],
+            content: $rawPost['content'],
+            id: $rawPost['id'],
+        );
+    }
+}

--- a/Database/Seeds/FollowSeeder.php
+++ b/Database/Seeds/FollowSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Seeds;
+
+use Database\AbstractSeeder;
+use Database\DAOFactory;
+
+class FollowSeeder extends AbstractSeeder
+{
+    protected ?string $tableName = 'follows';
+    protected array $tableColumns = [
+        'followeeId' => [
+            'data_type' => 'int',
+            'column_name' => 'followeeId'
+        ],
+        'followerId' => [
+            'data_type' => 'int',
+            'column_name' => 'followerId'
+        ],
+    ];
+
+    public function createRowData(int $num=1): array
+    {
+        $userDao = DAOFactory::getUserDAO();
+        $users = $userDao->getAll();
+        $ids = [];
+        foreach ($users as $user){
+            $ids[] = $user->getId();
+        }
+        $followerIds = $ids;
+        $followeeIds = $ids;
+
+        $data = [];
+        for ($i = 0; $i < $num; $i++){
+            $data[] = [
+                'followeeId' => $followeeIds[array_rand($followeeIds)],
+                'followerId' => $followerIds[array_rand($followerIds)],
+            ];
+        }
+        return $data;
+    }
+}

--- a/Database/Seeds/LikeSeeder.php
+++ b/Database/Seeds/LikeSeeder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Seeds;
+
+use Database\AbstractSeeder;
+use Database\DAOFactory;
+use Faker\Factory;
+
+class LikeSeeder extends AbstractSeeder
+{
+    protected ?string $tableName = 'likes';
+    protected array $tableColumns = [
+        'userId' => [
+            'data_type' => 'int',
+            'column_name' => 'userId'
+        ],
+        'postId' => [
+            'data_type' => 'int',
+            'column_name' => 'postId'
+        ],
+    ];
+
+    public function createRowData(int $num=1): array
+    {
+        $postDao = DAOFactory::getPostDAO();
+        $posts = $postDao->getAll();
+        $postIds = [];
+        foreach ($posts as $post){
+            $postIds[] = $post->getId();
+        }
+        $userDao = DAOFactory::getUserDAO();
+        $users = $userDao->getAll();
+        $userIds = [];
+        foreach ($users as $user){
+            $userIds[] = $user->getId();
+        }
+
+        $data = [];
+        $faker = Factory::create();
+        for ($i = 0; $i < $num; $i++){
+            $data[] = [
+                'userId' => $faker->randomElement($userIds),
+                'postId' => $faker->randomElement($postIds),
+            ];
+        }
+        return $data;
+    }
+}

--- a/Database/Seeds/PostSeeder.php
+++ b/Database/Seeds/PostSeeder.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Database\Seeds;
+
+use Database\AbstractSeeder;
+use Database\DAOFactory;
+use Faker\Factory;
+
+class PostSeeder extends AbstractSeeder
+{
+    protected ?string $tableName = 'posts';
+    protected array $tableColumns = [
+        'userId' => [
+            'data_type' => 'int',
+            'column_name' => 'userId'
+        ],
+        'content' => [
+            'data_type' => 'string',
+            'column_name' => 'content'
+        ],
+        'mediaUrl' => [
+            'data_type' => '?string',
+            'column_name' => 'mediaUrl'
+        ],
+        'isScheduled' => [
+            'data_type' => 'bool',
+            'column_name' => 'isScheduled'
+        ],
+        'scheduled_at' => [
+            'data_type' => '?string',
+            'column_name' => 'scheduled_at'
+        ],
+        'postDate' => [
+            'data_type' => 'string',
+            'column_name' => 'postDate'
+        ],
+    ];
+
+    public function createRowData(int $num=1): array
+    {
+
+        $userDao = DAOFactory::getUserDAO();
+        $users = $userDao->getAll();
+        $ids = [];
+        foreach ($users as $user){
+            $ids[] = $user->getId();
+        }
+        $userIds = $ids;
+
+        $data = [];
+        $faker = Factory::create();
+        for ($i=0; $i<$num; $i++){
+            $data[] = [
+                'userId' => $faker->randomElement($userIds),
+                'content' => $faker->text,
+                'mediaUrl' => null,
+                'isScheduled' => false,
+                'scheduled_at' => null,
+                'postDate' => $faker->dateTimeThisYear->format('Y-m-d H:i:s')
+            ];
+        }
+        return $data;
+    }
+}

--- a/Models/Follow.php
+++ b/Models/Follow.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Models;
+
+use Models\Interfaces\Model;
+use Models\Traits\GenericModel;
+
+class Follow implements Interfaces\Model
+{
+    use GenericModel;
+
+    public function __construct(
+        private int $followerId,
+        private int $followedId,
+    ){}
+
+    public function getFollowerId(): int {
+        return $this->followerId;
+    }
+
+    public function setFollowerId(int $followerId): void {
+        $this->followerId = $followerId;
+    }
+
+    public function getFollowedId(): int {
+        return $this->followedId;
+    }
+
+    public function setFollowedId(int $followedId): void {
+        $this->followedId = $followedId;
+    }
+}

--- a/Models/Like.php
+++ b/Models/Like.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Models;
+
+use Models\Interfaces\Model;
+use Models\Traits\GenericModel;
+
+class Like implements Interfaces\Model
+{
+    use GenericModel;
+
+    public function __construct(
+        private int $userId,
+        private int $postId,
+    ){}
+
+    public function getUserId(): int {
+        return $this->userId;
+    }
+
+    public function setUserId(int $userId): void {
+        $this->userId = $userId;
+    }
+
+    public function getPostId(): int {
+        return $this->postId;
+    }
+
+    public function setPostId(int $postId): void {
+        $this->postId = $postId;
+    }
+}

--- a/Models/Post.php
+++ b/Models/Post.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Models;
+
+use DateTime;
+use Models\Interfaces\Model;
+use Models\Traits\GenericModel;
+
+class Post implements Interfaces\Model
+{
+    use GenericModel;
+
+    public function __construct(
+        private int $userId,
+        private string $content,
+        private ?int $id = null,
+        private ?string $mediaUrl = null,
+        private ?bool $isScheduled = false,
+        private ?string $scheduledAt = null,
+        private ?DateTime $postDate = null,
+    ){}
+
+    public function getId(): ?int {
+        return $this->id;
+    }
+
+    public function setId(int $id): void {
+        $this->id = $id;
+    }
+
+    public function getUserId(): int {
+        return $this->userId;
+    }
+
+    public function setUserId(int $userId): void {
+        $this->userId = $userId;
+    }
+
+    public function getContent(): string {
+        return $this->content;
+    }
+
+    public function setContent(string $content): void {
+        $this->content = $content;
+    }
+
+    public function getMediaUrl(): ?string {
+        return $this->mediaUrl;
+    }
+
+    public function setMediaUrl(?string $mediaUrl): void {
+        $this->mediaUrl = $mediaUrl;
+    }
+
+    public function getIsScheduled(): ?bool {
+        return $this->isScheduled;
+    }
+
+    public function setIsScheduled(?bool $isScheduled): void {
+        $this->isScheduled = $isScheduled;
+    }
+
+    public function getScheduledAt(): ?string {
+        return $this->scheduledAt;
+    }
+
+    public function setScheduledAt(?string $scheduledAt): void {
+        $this->scheduledAt = $scheduledAt;
+    }
+
+    public function getPostDate(): ?DateTime {
+        return $this->postDate;
+    }
+
+    public function setPostDate(?DateTime $postDate): void {
+        $this->postDate = $postDate;
+    }
+}


### PR DESCRIPTION
このプルリクエストでは、データベース層に新しいデータアクセスオブジェクト（DAOs）とシーダーを導入し、対応するモデルクラスを追加しました。主な変更点は、`Follow`、`Like`、`Post`用のDAOs、シーダー、およびモデルの追加です。また、`AbstractSeeder`クラスのデータ型処理を改善しました。

### 新しいDAOsと実装:

* [`Database/DataAccess/FollowDAO.php`](diffhunk://#diff-48b4c28e6878c12ec236a8f974b3b85e8e17e44955ad99d2b9720dbf63d82616R1-R13):  
  フォロー関連のデータベース操作を処理する`FollowDAO`インターフェースを追加。
* [`Database/DataAccess/LikeDAO.php`](diffhunk://#diff-eebf92beac66c808974ae4894c4012d204cdbedd241d486ef64e17d38090a785R1-R13):  
  いいね関連のデータベース操作を処理する`LikeDAO`インターフェースを追加。
* [`Database/DataAccess/PostDAO.php`](diffhunk://#diff-7f4266f78b0daab5bd5945e5051fad180e1f2e66a1a303585877bd8fe2996f86R1-R14):  
  投稿関連のデータベース操作を処理する`PostDAO`インターフェースを追加。
* [`Database/Implementations/PostDAOImpl.php`](diffhunk://#diff-a7b839634cd9a280aa61a3fa908229297daf6de1aaff1b864783160fc41963e5R1-R67):  
  投稿の作成と取得を行う`PostDAO`インターフェースを実装。

### 新しいシーダー:

* [`Database/Seeds/FollowSeeder.php`](diffhunk://#diff-02d5d45780101aa7a8d387f40e03b8dfbb0bd53eb239a1ff4948923ebe8ae772R1-R42):  
  `follows`テーブルにサンプルデータを追加するシーダークラス。
* [`Database/Seeds/LikeSeeder.php`](diffhunk://#diff-0eb56c48cff9c9bd39a98987b2e6cce6eaf668073b9fed3560ec7654b51119d9R1-R48):  
  `likes`テーブルにサンプルデータを追加するシーダークラス。
* [`Database/Seeds/PostSeeder.php`](diffhunk://#diff-0ecec0a746ba2cdf43d64e6dbc96ee06d91f1b4a29053c9c83557e86216813dcR1-R64):  
  `posts`テーブルにサンプルデータを追加するシーダークラス。

### 新しいモデル:

* [`Models/Follow.php`](diffhunk://#diff-d57e01b9e176dab842979ee830ec339b411d570d2b16cb6e7df6bb1b6f786e66R1-R32):  
  必要なプロパティとメソッドを含む`Follow`モデルクラスを追加。
* [`Models/Like.php`](diffhunk://#diff-e18720b4c2242fee01490a1a788aa20eb455bf4e6e901e94d878d29c67fd3187R1-R32):  
  必要なプロパティとメソッドを含む`Like`モデルクラスを追加。
* [`Models/Post.php`](diffhunk://#diff-11f6ddc0028a066649b9ccf0ad3d366cc72763fc8e37b20f0569ad7c4ea2f9e6R1-R78):  
  必要なプロパティとメソッドを含む`Post`モデルクラスを追加。

### 既存クラスの更新:

* [`Database/AbstractSeeder.php`](diffhunk://#diff-0b44011147f0772b4a4fd696d106f85f5e52920c33d48d9acad7b400c939f58dR20-R21):  
  `AbstractSeeder`クラスに`bool`およびNULL可能な`bool`データ型の処理を追加。
* [`Database/AbstractSeeder.php`](diffhunk://#diff-0b44011147f0772b4a4fd696d106f85f5e52920c33d48d9acad7b400c939f58dR45-R52):  
  NULL可能な`int`および`string`データ型をより効果的に処理するために`validateRow`メソッドを改善。
* [`Database/DAOFactory.php`](diffhunk://#diff-70176f1acf77ae60a6a2ee04e8a026632a133d6c8709696c2cb226bafcfd269fR6-R9):  
  `PostDAO`インスタンスを取得するメソッドを追加し、`PostDAO`および`PostDAOImpl`の`use`ステートメントを追加。  
  [[1]](diffhunk://#diff-70176f1acf77ae60a6a2ee04e8a026632a133d6c8709696c2cb226bafcfd269fR6-R9)  [[2]](diffhunk://#diff-70176f1acf77ae60a6a2ee04e8a026632a133d6c8709696c2cb226bafcfd269fR23-R27)
