### PR TITLE
コメント機能の実装とデータベースシーディングの追加

### DIFF
--- a/Database/DataAccess/CommentDAO.php
+++ b/Database/DataAccess/CommentDAO.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Database\DataAccess;
+
+
+
+use Models\Comment;
+
+interface CommentDAO
+{
+    public function create(Comment $comment): bool;
+}

--- a/Database/Seeds/CommentSeeder.php
+++ b/Database/Seeds/CommentSeeder.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Database\Seeds;
+
+use Database\AbstractSeeder;
+use Database\DAOFactory;
+use Faker\Factory;
+
+class CommentSeeder extends AbstractSeeder
+{
+    protected ?string $tableName = 'comments';
+    protected array $tableColumns = [
+        'userId' => [
+            'data_type' => 'int',
+            'column_name' => 'userId'
+        ],
+        'postId' => [
+            'data_type' => 'int',
+            'column_name' => 'postId'
+        ],
+        'content' => [
+            'data_type' => 'string',
+            'column_name' => 'content'
+        ],
+        'commentDate' => [
+            'data_type' => 'string',
+            'column_name' => 'PostDate'
+        ],
+    ];
+
+    public function createRowData(int $n=1): array
+    {
+        $userDao = DAOFactory::getUserDAO();
+        $users = $userDao->getAll();
+        $userIds = [];
+        foreach ($users as $user){
+            $userIds[] = $user->getId();
+        }
+
+        $postDao = DAOFactory::getPostDAO();
+        $posts = $postDao->getAll();
+        $postIds = [];
+        foreach ($posts as $post){
+            $postIds[] = $post->getId();
+        }
+
+        $data = [];
+        $faker = Factory::create();
+        for ($i=0; $i<$n; $i++){
+            $data[] = [
+                'userId' => $faker->randomElement($userIds),
+                'postId' => $faker->randomElement($postIds),
+                'content' => $faker->text,
+                'commentDate' => $faker->dateTimeThisYear->format('Y-m-d H:i:s')
+            ];
+        }
+        return $data;
+    }
+}

--- a/Database/Seeds/PostSeeder.php
+++ b/Database/Seeds/PostSeeder.php
@@ -56,7 +56,7 @@ class PostSeeder extends AbstractSeeder
                 'mediaUrl' => null,
                 'isScheduled' => false,
                 'scheduled_at' => null,
-                'postDate' => $faker->dateTimeThisYear->format('Y-m-d H:i:s')
+                'postDate' => $faker->dateTimeThisCentury()->format('Y-m-d H:i:s')
             ];
         }
         return $data;

--- a/Models/Comment.php
+++ b/Models/Comment.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Models;
+
+use Models\Interfaces\Model;
+use Models\Traits\GenericModel;
+
+class Comment implements Interfaces\Model
+{
+    use GenericModel;
+
+    public function __construct(
+        private string $comment,
+        private int $postId,
+        private int $userId,
+        private ?int $id = null,
+        private ?string $postDate = null
+    ){}
+}


### PR DESCRIPTION
このプルリクエストでは、データベース内でコメントを処理する新しい機能を導入しました。主な変更点として、`CommentDAO`インターフェース、`CommentSeeder`クラス、`Comment`モデルの追加が含まれています。また、`PostSeeder`クラスに対して小規模な更新を行いました。

### コメント処理の新機能:

* [`Database/DataAccess/CommentDAO.php`](diffhunk://#diff-98fa1dddd9a0abf8bde6f036f4fac2870ca75951b5afec17e1ebdf2f93cd1038R1-R12):  
  コメントを作成するための`create`メソッドを含む`CommentDAO`インターフェースを追加。
* [`Models/Comment.php`](diffhunk://#diff-cfe4bea1f5c1161090132372ecb8eee9099461c203a847d2ff7d90a946f279e9R1-R19):  
  `Comment`モデルクラスを導入。`comment`、`postId`、`userId`、`id`、`postDate`のプロパティを持ち、`Model`インターフェースを実装し、`GenericModel`トレイトを使用。

### データベースシーディングの改善:

* [`Database/Seeds/CommentSeeder.php`](diffhunk://#diff-638b0d1a2fbeba2616ceb605b60d801a4a7f2e2272758d1bef28894b571bde97R1-R59):  
  コメントデータを生成およびシードする`CommentSeeder`クラスを追加。ユーザーID、投稿ID、内容、コメント日付を含む行データを作成するメソッドを実装。

### 小規模な更新:

* [`Database/Seeds/PostSeeder.php`](diffhunk://#diff-0ecec0a746ba2cdf43d64e6dbc96ee06d91f1b4a29053c9c83557e86216813dcL59-R59):  
  `postDate`の生成を`dateTimeThisYear`から`dateTimeThisCentury`に変更。
